### PR TITLE
Added "NewBattery" to hidden commands

### DIFF
--- a/hidden-commands.md
+++ b/hidden-commands.md
@@ -115,6 +115,13 @@ ClearFiles
     Life - ??
 ```
 
+### Other Hidden commands
+```
+NewBattery
+    (NOTE: Exact function unknown, but some users report this can fix an issue where a new battery isn't being charged)
+    Tells the robot a new battery has been installed.
+```
+
 ### Hidden gems looking at the decompiled code:
 ```
 YOU OVERFLOWED A 64-bit NUMBER!  WHAT WERE YOU THINKING???


### PR DESCRIPTION
Command `NewBattery` is known in the community and is referenced in couple of places as a fix for issue where the battery isn't being charged.

#### Robotreviews forum
https://www.robotreviews.com/chat/viewtopic.php?f=20&t=22992

#### Reddit
https://www.reddit.com/r/NeatoRobotics/comments/1bsaswt/neato_d7_battery_deep_discharge_error/


### Personal testing
I've tested it on my own D4. The robot responded with
```
New battery installed
```

I don't know, but suspect the command may: 
- tell the robot to re-calibrate its battery SoC estimations for the battery.
- reset any battery age counter and possible planned obsolescence feature.