### PR TITLE
fix small typo in gen3_card

### DIFF
--- a/config/home-assistant/gen3_card.yaml
+++ b/config/home-assistant/gen3_card.yaml
@@ -197,7 +197,7 @@ cards:
                             action: toggle
                         - type: custom:button-card
                           entity: button.neato_vacuum_manual_drive_turn_right_down
-                          name: Arc Right
+                          name: Right
                           press_action:
                             action: call-service
                             service: button.press


### PR DESCRIPTION
"Arc Right" should be "Right"